### PR TITLE
79 css fixes

### DIFF
--- a/src/components/OrderBook/OrderBook.js
+++ b/src/components/OrderBook/OrderBook.js
@@ -113,6 +113,7 @@ const Tab = styled.button`
 
 const Book = styled.div`
 	height: 100%;
+	min-height: 0;
 `;
 
 const SortIcon = styled.img`

--- a/src/components/OrderBook/OrderBook.js
+++ b/src/components/OrderBook/OrderBook.js
@@ -90,9 +90,6 @@ const Tabs = styled.div`
 		&:first-child {
 			margin-left: 0;
 		}
-		&:last-child {
-			margin-right: 0;
-		}
 	}
 `;
 
@@ -125,6 +122,9 @@ const SortIcon = styled.img`
 `;
 
 const ButtonSort = styled.button`
+	text-align: left;
+	display: flex;
+	align-items: center;
 	border: none;
 	outline: none;
 	cursor: pointer;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -16,6 +16,7 @@ export const Thead = styled.thead`
 
 export const Tbody = styled.tbody`
 	overflow: auto;
+	min-height: 0;
 `;
 
 export const Tr = styled.tr`

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -18,24 +18,27 @@ export const Tbody = styled.tbody`
 	overflow: auto;
 `;
 
-export const Tr = styled.tr``;
+export const Tr = styled.tr`
+	display: flex;
+`;
 
 export const Th = styled.th`
+	display: flex;
+	flex-direction: column;
+	flex-basis: 100%;
+	justify-content: center;
 	height: 42px;
 	line-height: 12px;
 	text-align: left;
 	padding: 0 18px;
-	&:last-child {
-		text-align: right;
-	}
 `;
 
 export const Td = styled.td`
+	display: flex;
+	flex-direction: column;
+	flex-basis: 100%;
 	text-align: left;
 	padding: 6px 18px;
-	&:last-child {
-		text-align: right;
-	}
 `;
 
 export const DataLabel = styled(DataSmall)`

--- a/src/components/WalletBox/WalletBox.js
+++ b/src/components/WalletBox/WalletBox.js
@@ -80,6 +80,7 @@ const Header = styled.div`
 
 const Body = styled.div`
 	height: 100%;
+	min-height: 0;
 `;
 
 const HeaderBlock = styled.div`

--- a/src/pages/Trade/Trade.js
+++ b/src/pages/Trade/Trade.js
@@ -28,7 +28,7 @@ const Trade = () => {
 					<BoxContainer margin="0 0 8px 0">
 						<ChartPanel />
 					</BoxContainer>
-					<BoxContainer height={'100%'}>
+					<BoxContainer style={{ minHeight: 0 }} height={'100%'}>
 						<OrderBook />
 					</BoxContainer>
 				</CentralContainer>
@@ -36,7 +36,7 @@ const Trade = () => {
 					<BoxContainer margin="0 0 8px 0">
 						<TradeBox />
 					</BoxContainer>
-					<BoxContainer height={'100%'}>
+					<BoxContainer style={{ minHeight: 0 }} height={'100%'}>
 						<WalletBox />
 					</BoxContainer>
 				</SmallContainer>
@@ -65,6 +65,7 @@ const TradeLayout = styled.div`
 	width: 100%;
 	flex: 1;
 	height: 100%;
+	min-height: 0;
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
I got all correct areas to be scrollable in brave, firefox and chrome.. 
But I wonder if we should set min height of 800px or so on the main container (the one with `height: 100vh`). Cause right now on a 13 inc screen the wallet balance is barely visible.

 **Or** we might have to make the whole righthand column scrollable .
![Screen Shot 2019-12-12 at 8 35 58 pm](https://user-images.githubusercontent.com/5688912/70700559-11520100-1d1f-11ea-9dea-800cb4161133.png)
