### PR TITLE
Style scrollbars

### DIFF
--- a/src/components/PairList/PairList.js
+++ b/src/components/PairList/PairList.js
@@ -163,9 +163,10 @@ const ButtonRow = styled.div`
 `;
 
 const List = styled.ul`
-	margin: 0 10px;
+	margin: 0 0 0 10px;
 	padding: 0;
-	overflow: auto;
+	overflow-y: auto;
+	overflow-x: hidden;
 `;
 
 const Pair = styled.li`

--- a/src/index.css
+++ b/src/index.css
@@ -42,3 +42,31 @@ body {
 		url('/fonts/apercu-light.woff2') format('woff2'), url('/fonts/apercu-light.woff') format('woff'),
 		url('/fonts/apercu-light.ttf') format('truetype');
 }
+/* Customize website's scrollbar like Mac OS
+/* total width */
+*::-webkit-scrollbar {
+	visibility: hidden;
+	background-color: transparent;
+	width: 8px;
+}
+
+/* background of the scrollbar except button or resizer */
+*::-webkit-scrollbar-track {
+	background-color: transparent;
+}
+
+/* scrollbar itself */
+*::-webkit-scrollbar-thumb {
+	background-color: rgba(0, 0, 0, 0.2);
+	border-radius: 16px;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	visibility: hidden;
+}
+*:hover::-webkit-scrollbar-thumb {
+	visibility: visible;
+}
+
+/* set button(top and bottom of the scrollbar) */
+*::-webkit-scrollbar-button {
+	display: none;
+}


### PR DESCRIPTION
Styled scroll bars. Tested in
MacOS: Chrome + Brave
Windows 10: Chrome

I didn't have a chance to test in brave on windows but it should look the same as in chrome.

Windows Chrome pic:
![Screen Shot 2020-01-18 at 2 12 04 pm](https://user-images.githubusercontent.com/5688912/72657799-12044400-39fd-11ea-9c2c-b27e8c6c448b.png)
