### PR TITLE
Implement loans page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,5 +1,10 @@
 {
 	"header": {
-		"connect-wallet": "Connect wallet"
+		"connect-wallet": "Connect wallet",
+		"links": {
+			"exchange": "EXCHANGE",
+			"loans": "LOANS",
+			"support": "SUPPORT"
+		}
 	}
 }

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-// import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useTranslation } from 'react-i18next';
 
 import Logo from '../Logo';
@@ -9,92 +8,90 @@ import ThemeSwitcher from '../ThemeSwitcher';
 import WalletAddressWidget from '../WalletAddressWidget';
 
 import { ButtonPrimarySmall } from '../Button';
-import { LabelMedium, DataMedium } from '../Typography';
+import { DataMedium } from '../Typography';
+import { labelMediumCSS } from '../Typography/Label';
 import { toggleWalletPopup } from '../../ducks/ui';
 import { getWalletInfo, getCurrentTheme } from '../../ducks';
+
+import { ROUTES } from '../../constants/routes';
+import { LINKS } from '../../constants/links';
+import { HEADER_HEIGHT } from '../../constants/ui';
+
+import { FlexDivCentered, ExternalLink, Link } from '../../shared/commonStyles';
 
 const Header = ({ toggleWalletPopup, walletInfo, theme }) => {
 	const { currentWallet, networkName } = walletInfo;
 	const { t } = useTranslation();
 
+	const showWalletPopup = () => toggleWalletPopup(true);
+
 	return (
 		<Container>
-			<HeaderBlock>
-				<Logo theme={theme} />
+			<HeaderSection>
+				<Link to={ROUTES.Root}>
+					<Logo theme={theme} />
+				</Link>
 				<Network>
-					<NetworkLabel>{networkName || 'mainnet'}</NetworkLabel>
+					<NetworkLabel>{networkName}</NetworkLabel>
 				</Network>
-			</HeaderBlock>
-			<HeaderBlock>
-				{/* <HeaderLink to={'/trade'}>
-					<HeaderLabel>Trade</HeaderLabel>
-				</HeaderLink>
-				<HeaderLink to={'/'}>
-					<HeaderLabel>Markets</HeaderLabel>
-				</HeaderLink>
-				<HeaderLink to={'/'}>
-					<HeaderLabel>Tokens</HeaderLabel>
-				</HeaderLink>
-				<HeaderLabel style={{ margin: '0 24px' }}>A / 诶</HeaderLabel> */}
-				<HeaderAnchor href="https://help.synthetix.io/hc/en-us" target="_blank">
-					<HeaderLabel>Support</HeaderLabel>
-				</HeaderAnchor>
+			</HeaderSection>
+			<HeaderSection>
+				<MenuLink to={ROUTES.Trade}>{t('header.links.exchange')}</MenuLink>
+				<MenuLink to={ROUTES.Loans}>{t('header.links.loans')}</MenuLink>
+				<ExternalMenuLink href={LINKS.Support}>{t('header.links.support')}</ExternalMenuLink>
 				<ThemeSwitcher />
-				{currentWallet ? (
+				{currentWallet != null ? (
 					<WalletAddressWidget />
 				) : (
-					<ButtonPrimarySmall onClick={() => toggleWalletPopup(true)}>
+					<ButtonPrimarySmall onClick={showWalletPopup}>
 						{t('header.connect-wallet')}
 					</ButtonPrimarySmall>
 				)}
-			</HeaderBlock>
+			</HeaderSection>
 		</Container>
 	);
 };
 
-const Container = styled.div`
-	height: 56px;
+const Container = styled(FlexDivCentered)`
+	height: ${HEADER_HEIGHT};
 	background-color: ${props => props.theme.colors.surfaceL3};
-	display: flex;
-	align-items: center;
 	padding: 0 24px;
 	justify-content: space-between;
 `;
 
-const Network = styled.div`
-	display: flex;
-	align-items: center;
+const Network = styled(FlexDivCentered)`
 	height: 32px;
 	background-color: ${props => props.theme.colors.accentDark};
 	margin-left: 26px;
 	padding: 0 12px;
 `;
 
-const HeaderBlock = styled.div`
-	display: flex;
-	align-items: center;
+const HeaderSection = styled(FlexDivCentered)`
 	& > * {
 		margin: 0 12px;
 	}
 `;
 
-const HeaderLabel = styled(LabelMedium)`
-	text-transform: uppercase;
+const menuLinkCSS = css`
+	${labelMediumCSS};
+	padding: 6px 20px;
 	color: ${props => props.theme.colors.fontTertiary};
 	&:hover {
+		background-color: ${props => props.theme.colors.accentLight};
 		color: ${props => props.theme.colors.fontSecondary};
 	}
 `;
 
-// const HeaderLink = styled(Link)`
-// 	text-decoration: none;
-// 	&:hover {
-// 		text-decoration: underline;
-// 	}
-// `;
+const MenuLink = styled(Link)`
+	${menuLinkCSS};
+	&.active {
+		background-color: ${props => props.theme.colors.accentLight};
+		color: ${props => props.theme.colors.fontSecondary};
+	}
+`;
 
-const HeaderAnchor = styled.a`
-	text-decoration: none;
+const ExternalMenuLink = styled(ExternalLink)`
+	${menuLinkCSS}
 `;
 
 const NetworkLabel = styled(DataMedium)`
@@ -102,12 +99,10 @@ const NetworkLabel = styled(DataMedium)`
 	color: ${props => props.theme.colors.fontTertiary};
 `;
 
-const mapStateToProps = state => {
-	return {
-		walletInfo: getWalletInfo(state),
-		theme: getCurrentTheme(state),
-	};
-};
+const mapStateToProps = state => ({
+	walletInfo: getWalletInfo(state),
+	theme: getCurrentTheme(state),
+});
 
 const mapDispatchToProps = {
 	toggleWalletPopup,

--- a/src/components/Typography/Label.js
+++ b/src/components/Typography/Label.js
@@ -1,16 +1,26 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { color } from 'styled-system';
 
-export const LabelMedium = styled.span`
-	${color}
-	font-size: 14px;
+export const labelCSS = css`
+	${color};
 	font-family: 'apercu-medium', sans-serif;
-	color: ${props => (props.color ? props.color : props.theme.colors.fontPrimary)};
+	color: ${props => props.color || props.theme.colors.fontPrimary};
+`;
+
+export const labelMediumCSS = css`
+	${labelCSS};
+	font-size: 14px;
+`;
+
+export const labelSmallCSS = css`
+	${labelCSS}
+	font-size: 12px;
+`;
+
+export const LabelMedium = styled.span`
+	${labelMediumCSS}
 `;
 
 export const LabelSmall = styled.span`
-	${color}
-	font-size: 12px;
-	font-family: 'apercu-medium', sans-serif;
-	color: ${props => (props.color ? props.color : props.theme.colors.fontPrimary)};
+	${labelSmallCSS}
 `;

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -1,0 +1,3 @@
+export const LINKS = {
+	Support: 'https://help.synthetix.io/hc/en-us',
+};

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,5 @@
+export const ROUTES = {
+	Root: '/',
+	Trade: '/trade',
+	Loans: '/loans',
+};

--- a/src/constants/ui.js
+++ b/src/constants/ui.js
@@ -1,0 +1,1 @@
+export const HEADER_HEIGHT = '56px';

--- a/src/ducks/wallet.js
+++ b/src/ducks/wallet.js
@@ -1,5 +1,6 @@
 import { setSigner } from '../utils/snxJSConnector';
 import { getAddress } from '../utils/formatters';
+import { defaultNetwork } from '../utils/networkUtils';
 
 const UPDATE_WALLET_STATUS = 'WALLET/UPDATE_WALLET_STATUS';
 const RESET_WALLET_STATUS = 'WALLET/RESET_WALLET_STATUS';
@@ -15,8 +16,8 @@ const defaultState = {
 	currentWallet: null,
 	derivationPath: localStorage.getItem('derivationPath'),
 	balances: null,
-	networkId: null,
-	networkName: null,
+	networkId: defaultNetwork.networkId,
+	networkName: defaultNetwork.networkName,
 };
 
 // Reducer

--- a/src/pages/Loans/Loans.js
+++ b/src/pages/Loans/Loans.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { PageLayout } from '../../shared/commonStyles';
+
+const Loans = () => <PageLayout>Loans</PageLayout>;
+
+export default Loans;

--- a/src/pages/Loans/index.js
+++ b/src/pages/Loans/index.js
@@ -1,0 +1,1 @@
+export { default } from './Loans';

--- a/src/pages/Root/Root.js
+++ b/src/pages/Root/Root.js
@@ -3,7 +3,7 @@ import { hot } from 'react-hot-loader/root';
 import React, { useEffect, useState, useCallback } from 'react';
 import styled from 'styled-components';
 import { ThemeProvider } from 'styled-components';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import snxJSConnector from '../../utils/snxJSConnector';
@@ -20,10 +20,16 @@ import {
 import { updateWalletStatus, updateWalletBalances } from '../../ducks/wallet';
 import { setExchangeFeeRate, setNetworkGasInfo } from '../../ducks/transaction';
 
+import { MainLayout } from '../../shared/commonStyles';
+import Header from '../../components/Header';
+import WalletPopup from '../../components/WalletPopup';
+import GweiPopup from '../../components/GweiPopup';
+
 import Trade from '../Trade';
-import Home from '../Home';
+import Loans from '../Loans';
 
 import { lightTheme, darkTheme } from '../../styles/theme';
+import { ROUTES } from '../../constants/routes';
 
 const Root = ({
 	setAvailableSynths,
@@ -91,20 +97,20 @@ const Root = ({
 
 	return (
 		<ThemeProvider theme={themeStyle}>
-			<div>
-				<Router>
-					<RootContainer>
+			<Router history={history}>
+				<RootContainer>
+					<MainLayout>
+						<Header />
+						<WalletPopup />
+						<GweiPopup />
 						<Switch>
-							<Route path="/trade">
-								<Trade />
-							</Route>
-							<Route path="/">
-								<Trade />
-							</Route>
+							<Route path={ROUTES.Trade} component={Trade} />
+							<Route path={ROUTES.Loans} component={Loans} />
+							<Redirect to={ROUTES.Trade} />
 						</Switch>
-					</RootContainer>
-				</Router>
-			</div>
+					</MainLayout>
+				</RootContainer>
+			</Router>
 		</ThemeProvider>
 	);
 };

--- a/src/pages/Trade/Trade.js
+++ b/src/pages/Trade/Trade.js
@@ -1,81 +1,44 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import styled from 'styled-components';
 
-import { getAvailableSynths } from '../../ducks';
-
-import Header from '../../components/Header';
 import PairList from '../../components/PairList';
 import ChartPanel from '../../components/ChartPanel';
 import OrderBook from '../../components/OrderBook';
 import TradeBox from '../../components/TradeBox';
 import WalletBox from '../../components/WalletBox';
 
-import WalletPopup from '../../components/WalletPopup';
-import GweiPopup from '../../components/GweiPopup';
+import { PageLayout, FlexDivCol } from '../../shared/commonStyles';
 
-const Trade = () => {
-	return (
-		<MainLayout>
-			<WalletPopup />
-			<GweiPopup />
-			<Header />
-			<TradeLayout>
-				<Container>
-					<BoxContainer height={'100%'}>
-						<PairList />
-					</BoxContainer>
-				</Container>
-				<CentralContainer>
-					<BoxContainer margin="0 0 8px 0">
-						<ChartPanel />
-					</BoxContainer>
-					<BoxContainer style={{ minHeight: 0 }} height={'100%'}>
-						<OrderBook />
-					</BoxContainer>
-				</CentralContainer>
-				<SmallContainer>
-					<BoxContainer margin="0 0 8px 0">
-						<TradeBox />
-					</BoxContainer>
-					<BoxContainer style={{ minHeight: 0 }} height={'100%'}>
-						<WalletBox />
-					</BoxContainer>
-				</SmallContainer>
-			</TradeLayout>
-		</MainLayout>
-	);
-};
+const Trade = () => (
+	<PageLayout>
+		<Container>
+			<BoxContainer height="100%">
+				<PairList />
+			</BoxContainer>
+		</Container>
+		<CentralContainer>
+			<BoxContainer margin="0 0 8px 0">
+				<ChartPanel />
+			</BoxContainer>
+			<BoxContainer style={{ minHeight: 0 }} height="100%">
+				<OrderBook />
+			</BoxContainer>
+		</CentralContainer>
+		<SmallContainer>
+			<BoxContainer margin="0 0 8px 0">
+				<TradeBox />
+			</BoxContainer>
+			<BoxContainer style={{ minHeight: 0 }} height="100%">
+				<WalletBox />
+			</BoxContainer>
+		</SmallContainer>
+	</PageLayout>
+);
 
-const mapStateToProps = state => {
-	return {
-		synths: getAvailableSynths(state),
-	};
-};
-
-const MainLayout = styled.div`
-	display: flex;
-	flex-flow: column;
-	width: 100%;
-	height: 100vh;
-	color: white;
-	position: relative;
-`;
-
-const TradeLayout = styled.div`
-	display: flex;
-	width: 100%;
-	flex: 1;
-	height: 100%;
-	min-height: 0;
-`;
-
-const Container = styled.div`
+const Container = styled(FlexDivCol)`
 	width: 25%;
 	min-width: 300px;
 	max-width: 400px;
-	display: flex;
-	flex-direction: column;
 	margin: 8px;
 	height: calc(100% - 16px);
 `;
@@ -85,17 +48,15 @@ const SmallContainer = styled(Container)`
 	min-width: 300px;
 `;
 
-const CentralContainer = styled.div`
+const CentralContainer = styled(FlexDivCol)`
 	flex: 1;
-	display: flex;
-	flex-direction: column;
 	margin: 8px 0;
 	min-width: 0;
 `;
 
 const BoxContainer = styled.div`
-	margin: ${props => (props.margin ? props.margin : '0')};
-	height: ${props => (props.height ? props.height : 'auto')};
+	margin: ${props => props.margin || '0'};
+	height: ${props => props.height || 'auto'};
 `;
 
-export default connect(mapStateToProps, null)(Trade);
+export default Trade;

--- a/src/shared/commonStyles.js
+++ b/src/shared/commonStyles.js
@@ -1,0 +1,50 @@
+import styled, { css } from 'styled-components';
+import { NavLink } from 'react-router-dom';
+
+export const FlexDiv = styled.div`
+	display: flex;
+`;
+
+export const FlexDivCentered = styled(FlexDiv)`
+	align-items: center;
+`;
+
+export const FlexDivCol = styled(FlexDiv)`
+	flex-direction: column;
+`;
+
+export const MainLayout = styled(FlexDiv)`
+	flex-flow: column;
+	width: 100%;
+	height: 100vh;
+	/* TODO: get color from theme */
+	color: white;
+	position: relative;
+`;
+
+export const PageLayout = styled(FlexDiv)`
+	width: 100%;
+	height: 100%;
+	flex: 1;
+	min-height: 0;
+`;
+
+export const linkCSS = css`
+	text-decoration: none;
+	&:hover {
+		text-decoration: none;
+	}
+`;
+
+export const ExternalLink = styled.a.attrs({
+	target: '_blank',
+	rel: 'noopener',
+})`
+	${linkCSS};
+`;
+
+export const Link = styled(NavLink).attrs({
+	activeClassName: 'active',
+})`
+	${linkCSS};
+`;

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -1,0 +1,3 @@
+import history from 'history';
+
+export default history.createBrowserHistory();


### PR DESCRIPTION
@justinjmoses @clementbalestrat this PR is going to be pretty big, so it's probably best to review it by commits. Early feedback is welcomed (this is still a work in progress)

My goal is to use translations / stories and best practices for the new code (and refactor existing one if needed)

- [x] Implement header links
- [x] Extract common components from the trade page (put it in Root / commonStyles)
- [x] Implement routing and initial boilerplate for Loans page
- [ ] Implement "empty boxes" for all the different sections
- [ ] Implement eth collateral dashboard (UI only)
- [ ] Implement create loan (UI only)
- [ ] Implement "my loans" (UI only) using react-table
- [ ] Hook data
- [ ] Add loaders where needed
- [ ] Implement header "new" feature
- [ ] Implement trade "borrow or buy" banner in pair list

Fixes #113 