### PR TITLE
Adds collateral banner

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2,9 +2,12 @@
 	"header": {
 		"connect-wallet": "Connect wallet",
 		"links": {
-			"exchange": "EXCHANGE",
-			"loans": "LOANS",
-			"support": "SUPPORT"
+			"exchange": "exchange",
+			"loans": "loans",
+			"support": "support"
+		},
+		"announcements": {
+			"ether-collateral": "NEW: ETH Collateral is live!"
 		}
 	},
 	"exchange": {

--- a/src/components/Button/ButtonPrimary.js
+++ b/src/components/Button/ButtonPrimary.js
@@ -1,5 +1,13 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { width } from 'styled-system';
+
+const smallButtonCSS = css`
+	height: 32px;
+	font-size: 14px;
+	padding: 0 12px;
+	width: auto;
+	line-height: 34px;
+`;
 
 const ButtonPrimary = styled.button`
 	border-radius: 1px;
@@ -7,7 +15,7 @@ const ButtonPrimary = styled.button`
 	width: 100%;
 	font-size: 16px;
 	letter-spacing: 0.5px;
-	font-family: 'apercu-medium', sans-serif;
+	font-family: ${props => props.theme.fonts.medium};
 	color: ${props => props.theme.colors.white};
 	cursor: pointer;
 	padding: 0 6px;
@@ -25,15 +33,12 @@ const ButtonPrimary = styled.button`
 	text-transform: uppercase;
 	line-height: 44px;
 	white-space: nowrap;
-	${width}
+	${width};
+	${props => props.size === 'sm' && smallButtonCSS}
 `;
 
 export const ButtonPrimarySmall = styled(ButtonPrimary)`
-	height: 32px;
-	font-size: 14px;
-	padding: 0 12px;
-	width: auto;
-	line-height: 34px;
+	${smallButtonCSS}
 `;
 
 export default ButtonPrimary;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,13 +2,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 import styled, { css } from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import { Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import Logo from '../Logo';
 import ThemeSwitcher from '../ThemeSwitcher';
 import WalletAddressWidget from '../WalletAddressWidget';
 
-import { ButtonPrimarySmall } from '../Button';
+import history from '../../utils/history';
+
+import { ButtonPrimary } from '../Button';
 import { DataMedium } from '../Typography';
 import { labelMediumCSS } from '../Typography/Label';
 import { showWalletPopup } from '../../ducks/ui';
@@ -33,6 +36,23 @@ export const Header = ({ showWalletPopup, walletInfo, currentTheme }) => {
 				<Network>
 					<NetworkLabel>{networkName}</NetworkLabel>
 				</Network>
+				<Switch>
+					<Route
+						path={ROUTES.Loans}
+						render={() => (
+							<StyledButton size="sm" disabled={true}>
+								{t('header.announcements.ether-collateral')}
+							</StyledButton>
+						)}
+					/>
+					<Route
+						render={() => (
+							<StyledButton size="sm" onClick={() => history.push(ROUTES.Loans)}>
+								{t('header.announcements.ether-collateral')}
+							</StyledButton>
+						)}
+					/>
+				</Switch>
 			</HeaderSection>
 			<HeaderSection>
 				<MenuLink to={ROUTES.Trade}>{t('header.links.exchange')}</MenuLink>
@@ -42,9 +62,9 @@ export const Header = ({ showWalletPopup, walletInfo, currentTheme }) => {
 				{currentWallet != null ? (
 					<WalletAddressWidget walletInfo={walletInfo} />
 				) : (
-					<ButtonPrimarySmall onClick={showWalletPopup}>
+					<ButtonPrimary size="sm" onClick={showWalletPopup}>
 						{t('header.connect-wallet')}
-					</ButtonPrimarySmall>
+					</ButtonPrimary>
 				)}
 			</HeaderSection>
 		</Container>
@@ -85,6 +105,7 @@ const menuLinkCSS = css`
 		background-color: ${props => props.theme.colors.accentLight};
 		color: ${props => props.theme.colors.fontSecondary};
 	}
+	text-transform: uppercase;
 `;
 
 const MenuLink = styled(Link)`
@@ -96,12 +117,16 @@ const MenuLink = styled(Link)`
 `;
 
 const ExternalMenuLink = styled(ExternalLink)`
-	${menuLinkCSS}
+	${menuLinkCSS};
 `;
 
 const NetworkLabel = styled(DataMedium)`
 	text-transform: uppercase;
 	color: ${props => props.theme.colors.fontTertiary};
+`;
+
+const StyledButton = styled(ButtonPrimary)`
+	text-transform: none;
 `;
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
<img width="219" alt="Screen Shot 2020-02-21 at 9 17 35 am" src="https://user-images.githubusercontent.com/254095/74990081-62584100-5496-11ea-93b9-f502f5ff0729.png">

I have also added "sm" size prop to `Button`. When we refactor `Button` component we would also add a "type" or "palette" to it and pass "primary", "secondary", etc.