### PR TITLE
Fetch balances from redux + add refresh on loans page

### DIFF
--- a/src/ducks/index.js
+++ b/src/ducks/index.js
@@ -55,6 +55,8 @@ export const getWalletBalances = state => {
 	return state.wallet.balances;
 };
 
+export const getIsFetchingWalletBalances = state => state.wallet.isFetchingWalletBalances;
+
 // SYNTHS REDUCERS
 export const getAvailableSynths = state => {
 	return state.synths.availableSynths;

--- a/src/pages/Loans/Loans.js
+++ b/src/pages/Loans/Loans.js
@@ -17,14 +17,16 @@ import Spinner from '../../components/Spinner';
 
 import { CRYPTO_CURRENCY_MAP, SYNTHS_MAP } from '../../constants/currency';
 import { bigNumberFormatter } from '../../utils/formatters';
+
 import { updateLoan, LOAN_STATUS } from '../../ducks/loans';
+import { fetchWalletBalances } from '../../ducks/wallet';
 
 const LOAN_EVENTS = {
 	LOAN_CREATED: 'LoanCreated',
 	LOAN_CLOSED: 'LoanClosed',
 };
 
-const Loans = ({ updateLoan }) => {
+const Loans = ({ updateLoan, fetchWalletBalances }) => {
 	const [selectedLoan, setSelectedLoan] = useState(null);
 	const [collateralPair, setCollateralPair] = useState(null);
 	const [initialized, setInitialized] = useState(false);
@@ -75,8 +77,8 @@ const Loans = ({ updateLoan }) => {
 			} = snxJSConnector;
 
 			EtherCollateral.contract.on(LOAN_EVENTS.LOAN_CREATED, (_account, loanID, _amount, tx) => {
-				console.log(_account, loanID, _amount, tx);
 				fetchContractData();
+				fetchWalletBalances();
 				updateLoan({
 					transactionHash: tx.transactionHash,
 					loanInfo: {
@@ -87,8 +89,8 @@ const Loans = ({ updateLoan }) => {
 			});
 
 			EtherCollateral.contract.on(LOAN_EVENTS.LOAN_CLOSED, (_, loanID) => {
-				console.log(loanID);
 				fetchContractData();
+				fetchWalletBalances();
 				updateLoan({
 					loanID: Number(loanID),
 					loanInfo: {
@@ -158,6 +160,7 @@ const LoanCardsContainer = styled.div`
 
 const mapDispatchToProps = {
 	updateLoan,
+	fetchWalletBalances,
 };
 
 export default connect(null, mapDispatchToProps)(Loans);

--- a/src/pages/Loans/components/Dashboard/Dashboard.js
+++ b/src/pages/Loans/components/Dashboard/Dashboard.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import Card from '../../../../components/Card';
 import { HeadingSmall } from '../../../../components/Typography';
-import { getWalletInfo } from '../../../../ducks';
+import { getWalletInfo, getIsFetchingWalletBalances } from '../../../../ducks';
 
 import { getCurrencyKeyBalance } from '../../../../utils/balances';
 import {
@@ -19,8 +19,13 @@ import { CARD_HEIGHT } from '../../../../constants/ui';
 
 import { InfoBox, InfoBoxLabel, InfoBoxValue, CurrencyKey } from '../../../../shared/commonStyles';
 import { EMPTY_BALANCE } from '../../../../constants/placeholder';
+import Spinner from '../../../../components/Spinner';
 
-export const Dashboard = ({ walletInfo: { balances, currentWallet }, collateralPair }) => {
+export const Dashboard = ({
+	walletInfo: { balances, currentWallet },
+	collateralPair,
+	isFetchingWalletBalances,
+}) => {
 	const { t } = useTranslation();
 
 	const {
@@ -103,10 +108,13 @@ export const Dashboard = ({ walletInfo: { balances, currentWallet }, collateralP
 					</LoanInfoRow>
 				</Card.Body>
 			</Card>
-			<Table cellPadding="0" cellPadding="0">
+			<Table cellSpacing="0" cellPadding="0">
 				<thead>
 					<TableRowHeader>
-						<th style={{ width: '60%' }}>{t('common.wallet.your-wallet')}</th>
+						<WalletBalancesHeading>
+							<span>{t('common.wallet.your-wallet')}</span>
+							{isFetchingWalletBalances && <Spinner size="sm" />}
+						</WalletBalancesHeading>
 						<th>{t('common.wallet.currency-balance', { currencyKey: loanCurrencyKey })}</th>
 						<th>
 							{t('common.wallet.currency-balance', {
@@ -139,6 +147,16 @@ Dashboard.propTypes = {
 	walletInfo: PropTypes.object,
 	collateralPair: PropTypes.object,
 };
+
+const WalletBalancesHeading = styled.th`
+	width: 60%;
+	display: flex;
+	align-items: center;
+
+	> * + * {
+		margin-left: 10px;
+	}
+`;
 
 const LoanInfoRow = styled.div`
 	display: grid;
@@ -183,6 +201,7 @@ const TableRowHeader = styled.tr`
 
 const mapStateToProps = state => ({
 	walletInfo: getWalletInfo(state),
+	isFetchingWalletBalances: getIsFetchingWalletBalances(state),
 });
 
 export default connect(mapStateToProps, null)(Dashboard);


### PR DESCRIPTION
@clementbalestrat now that it's possible to get balances from redux, it's handy to check for `getIsFetchingWalletBalances` where ever we want to show a loading indicator for fetching balances.

Note: Kovan was down for me, so I couldn't check if the balance updated after an open/close loan.

<img width="989" alt="Screen Shot 2020-02-21 at 4 50 54 pm" src="https://user-images.githubusercontent.com/254095/75008397-06101400-54cc-11ea-8ac9-0e1333650a67.png">
