### PR TITLE
fix: puts no-unused-vars as warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,6 @@ module.exports = {
 		'react/jsx-uses-vars': 2,
 		'react-hooks/rules-of-hooks': 'error',
 		'react-hooks/exhaustive-deps': 'warn',
+		'no-unused-vars': 'warn',
 	},
 };


### PR DESCRIPTION
I think it really hurts the developer experience... I have to comment multiple lines just to get it compiled while debugging. Let's have it as a warning.