### PR TITLE
Ensure snxJSConnector is initialized before rendering the app

### DIFF
--- a/src/components/TradeBox/TradeBox.js
+++ b/src/components/TradeBox/TradeBox.js
@@ -118,7 +118,6 @@ const TradeBox = ({
 	useEffect(() => {
 		const getFeeRateForExchange = async () => {
 			try {
-				if (!snxJSConnector.initialized) return;
 				const feeRateForExchange = await snxJSConnector.snxJS.Exchanger.feeRateForExchange(
 					bytesFormatter(quote.name),
 					bytesFormatter(base.name)
@@ -133,7 +132,7 @@ const TradeBox = ({
 		setQuoteAmount('');
 		getFeeRateForExchange();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [base.name, quote.name, snxJSConnector.initialized]);
+	}, [base.name, quote.name]);
 
 	useEffect(() => {
 		const getGasEstimate = async () => {
@@ -169,7 +168,7 @@ const TradeBox = ({
 
 	const getMaxSecsLeftInWaitingPeriod = useCallback(async () => {
 		try {
-			if (!snxJSConnector.initialized || !currentWallet) return;
+			if (!currentWallet) return;
 			const maxSecsLeftInWaitingPeriod = await snxJSConnector.snxJS.Exchanger.maxSecsLeftInWaitingPeriod(
 				currentWallet,
 				bytesFormatter(quote.name)
@@ -187,29 +186,23 @@ const TradeBox = ({
 			console.log(e);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [quote.name, snxJSConnector.initialized, currentWallet]);
+	}, [quote.name, currentWallet]);
 
 	useEffect(() => {
 		getMaxSecsLeftInWaitingPeriod();
 	}, [getMaxSecsLeftInWaitingPeriod]);
 
 	useEffect(() => {
-		if (snxJSConnector.initialized) {
-			const {
-				snxJS: { Synthetix },
-			} = snxJSConnector;
-			Synthetix.contract.on(EXCHANGE_EVENTS.SYNTH_EXCHANGE, fetchWalletBalances);
-		}
+		const {
+			snxJS: { Synthetix },
+		} = snxJSConnector;
+		Synthetix.contract.on(EXCHANGE_EVENTS.SYNTH_EXCHANGE, fetchWalletBalances);
+
 		return () => {
-			if (snxJSConnector.initialized) {
-				const {
-					snxJS: { Synthetix },
-				} = snxJSConnector;
-				Synthetix.contract.removeAllListeners(EXCHANGE_EVENTS.SYNTH_EXCHANGE);
-			}
+			Synthetix.contract.removeAllListeners(EXCHANGE_EVENTS.SYNTH_EXCHANGE);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [snxJSConnector.initialized]);
+	}, []);
 
 	const baseBalance = (synthsBalances && synthsBalances[base.name]) || 0;
 	const quoteBalance = (synthsBalances && synthsBalances[quote.name]) || 0;

--- a/src/pages/Root/Root.js
+++ b/src/pages/Root/Root.js
@@ -28,6 +28,7 @@ import { MainLayout } from '../../shared/commonStyles';
 import Header from '../../components/Header';
 import WalletPopup from '../../components/WalletPopup';
 import GweiPopup from '../../components/GweiPopup';
+import Spinner from '../../components/Spinner';
 
 import Trade from '../Trade';
 import Loans from '../Loans';
@@ -49,6 +50,7 @@ const Root = ({
 	fetchWalletBalances,
 }) => {
 	const [intervalId, setIntervalId] = useState(null);
+	const [appReady, setAppReady] = useState(false);
 	const fetchAndSetExchangeData = useCallback(async synths => {
 		const {
 			exchangeRates,
@@ -77,6 +79,7 @@ const Root = ({
 			const { networkId, name } = await getEthereumNetwork();
 			if (!snxJSConnector.initialized) {
 				snxJSConnector.setContractSettings({ networkId });
+				setAppReady(true);
 			}
 			updateWalletStatus({ networkId, networkName: name.toLowerCase() });
 			const synths = snxJSConnector.snxJS.contractSettings.synths.filter(synth => synth.asset);
@@ -102,14 +105,22 @@ const Root = ({
 			<Router history={history}>
 				<GlobalStyle />
 				<MainLayout>
-					<Header />
-					<WalletPopup />
-					<GweiPopup />
-					<Switch>
-						<Route path={ROUTES.Trade} component={Trade} />
-						<Route path={ROUTES.Loans} component={Loans} />
-						<Redirect to={ROUTES.Trade} />
-					</Switch>
+					{appReady ? (
+						<>
+							<Header />
+							<WalletPopup />
+							<GweiPopup />
+							<Switch>
+								<Route path={ROUTES.Trade} component={Trade} />
+								<Route path={ROUTES.Loans} component={Loans} />
+								<Redirect to={ROUTES.Trade} />
+							</Switch>
+						</>
+					) : (
+						<>
+							<Spinner fullscreen={true} size="sm" />
+						</>
+					)}
 				</MainLayout>
 			</Router>
 		</ThemeProvider>


### PR DESCRIPTION
This isn't the ideal loader, and it will certainly improve + have a fallback.
The rationale behind this decision was that we want to get rid of all these checks. Pages within the app will now assume that `snxJSConnector` is `initialized`.

I ran sanity tests, and it looks good to me.