### PR TITLE
fix: white color for footer menu title

### DIFF
--- a/src/pages/Root/components/HomeLayout/Footer/Footer.js
+++ b/src/pages/Root/components/HomeLayout/Footer/Footer.js
@@ -208,6 +208,7 @@ const Menu = styled.div`
 const MenuTitle = styled.div`
 	text-transform: uppercase;
 	${bodyMediumCSS};
+	color: ${props => props.theme.colors.white};
 	padding-bottom: 25px;
 `;
 


### PR DESCRIPTION
Fixes:

<img width="668" alt="Screen Shot 2020-04-02 at 2 20 14 pm" src="https://user-images.githubusercontent.com/254095/78207811-7314c180-74ee-11ea-840f-562d625ccd78.png">

This happens when you are on a light theme and on splash/markets page.
