### PR TITLE
Add a first time tooltip for markets that have withdrawals disabled

### DIFF
--- a/src/components/DismissableMessage/DismissableMessage.tsx
+++ b/src/components/DismissableMessage/DismissableMessage.tsx
@@ -33,6 +33,7 @@ const StyledMessage = styled(Message)`
 
 const StyledCloseButton = styled(CloseIcon)`
 	cursor: pointer;
+	flex-shrink: 0;
 `;
 
 export default DismissableMessage;

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,5 +1,5 @@
 export const LOCAL_STORAGE_KEYS = {
 	WALLET_DERIVATION_PATH: 'derivationPath',
 	APP_BANNER_DISMISSED: 'appBannerDismissed',
-	BO_WITHDRAWALS_DISABLED_TOOLTIP_DISMISSED: 'boWithdrawalsDisabledDismissed',
+	BO_WITHDRAWALS_DISABLED_TOOLTIP_DISMISSED: 'boWithdrawalsDisabledTooltipDismissed',
 };

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,4 +1,5 @@
 export const LOCAL_STORAGE_KEYS = {
 	WALLET_DERIVATION_PATH: 'derivationPath',
 	APP_BANNER_DISMISSED: 'appBannerDismissed',
+	BO_WITHDRAWALS_DISABLED_TOOLTIP_DISMISSED: 'boWithdrawalsDisabledDismissed',
 };

--- a/src/pages/Options/Market/TradeCard/BiddingPhaseCard/BiddingPhaseCard.tsx
+++ b/src/pages/Options/Market/TradeCard/BiddingPhaseCard/BiddingPhaseCard.tsx
@@ -402,11 +402,12 @@ const BiddingPhaseCard: FC<BiddingPhaseCardProps> = ({
 		}
 	};
 
-	const withdrawalsDisabledTab = (
-		<TabDisabled>
-			{t('options.market.trade-card.bidding.refund.title')} <BlockedIcon />
-		</TabDisabled>
-	);
+	const handleDismissWithdrawalsTooltip = () => {
+		setWithdrawalsDisabledTooltipDismissedMarkets([
+			...withdrawalsDisabledTooltipDismissedMarkets,
+			optionsMarket.address,
+		]);
+	};
 
 	return (
 		<Card>
@@ -419,44 +420,15 @@ const BiddingPhaseCard: FC<BiddingPhaseCardProps> = ({
 						{t('options.market.trade-card.bidding.refund.title')}
 					</TabButton>
 				) : (
-					<>
-						{withdrawalsDisabledTooltipDismissed ? (
-							<WithdrawalsTooltip
-								key="withdrawalsTooltip"
-								title={
-									<span>{t('options.market.trade-card.bidding.refund.disabled.tooltip')}</span>
-								}
-								placement="top"
-								arrow={true}
-							>
-								{withdrawalsDisabledTab}
-							</WithdrawalsTooltip>
-						) : (
-							<PaddedWithdrawalsTooltip
-								key="dismissibleWithdrawalsTooltip"
-								open={true}
-								title={
-									<StyledDismissableMessage
-										size="sm"
-										type="info"
-										onDismiss={() =>
-											setWithdrawalsDisabledTooltipDismissedMarkets([
-												...withdrawalsDisabledTooltipDismissedMarkets,
-												optionsMarket.address,
-											])
-										}
-									>
-										{t('options.market.trade-card.bidding.refund.disabled.first-time-tooltip')}
-									</StyledDismissableMessage>
-								}
-								interactive={true}
-								placement="bottom"
-								arrow={true}
-							>
-								{withdrawalsDisabledTab}
-							</PaddedWithdrawalsTooltip>
-						)}
-					</>
+					<WithdrawalsTooltip
+						title={<span>{t('options.market.trade-card.bidding.refund.disabled.tooltip')}</span>}
+						placement="top"
+						arrow={true}
+					>
+						<TabDisabled>
+							{t('options.market.trade-card.bidding.refund.title')} <BlockedIcon />
+						</TabDisabled>
+					</WithdrawalsTooltip>
 				)}
 			</StyledCardHeader>
 			<StyledCardBody>
@@ -509,36 +481,54 @@ const BiddingPhaseCard: FC<BiddingPhaseCardProps> = ({
 						fees={fees}
 						amount={isLong ? longSideAmount : shortSideAmount}
 					/>
-					{hasAllowance ? (
-						<Tooltip
-							open={isBid && Math.abs(priceShift) > SLIPPAGE_THRESHOLD}
-							title={<span>{t(`${transKey}.confirm-button.high-slippage`)}</span>}
-							arrow={true}
-							placement="bottom"
-						>
-							<ActionButton
-								size="lg"
-								palette="primary"
-								disabled={isBidding || !isWalletConnected || !sUSDBalance || !gasLimit}
-								onClick={handleBidOrRefund}
+					<PaddedWithdrawalsTooltip
+						open={optionsMarket.withdrawalsEnabled ? false : !withdrawalsDisabledTooltipDismissed}
+						title={
+							<StyledDismissableMessage
+								size="sm"
+								type="info"
+								onDismiss={handleDismissWithdrawalsTooltip}
 							>
-								{!isBidding
-									? t(`${transKey}.confirm-button.label`)
-									: t(`${transKey}.confirm-button.progress-label`)}
-							</ActionButton>
-						</Tooltip>
-					) : (
-						<ActionButton
-							size="lg"
-							palette="primary"
-							disabled={isAllowing || !isWalletConnected}
-							onClick={handleAllowance}
-						>
-							{!isAllowing
-								? t('common.enable-wallet-access.label')
-								: t('common.enable-wallet-access.progress-label')}
-						</ActionButton>
-					)}
+								{t('options.market.trade-card.bidding.refund.disabled.first-time-tooltip')}
+							</StyledDismissableMessage>
+						}
+						interactive={true}
+						placement="top"
+						arrow={true}
+					>
+						<span>
+							{hasAllowance ? (
+								<Tooltip
+									open={isBid && Math.abs(priceShift) > SLIPPAGE_THRESHOLD}
+									title={<span>{t(`${transKey}.confirm-button.high-slippage`)}</span>}
+									arrow={true}
+									placement="bottom"
+								>
+									<ActionButton
+										size="lg"
+										palette="primary"
+										disabled={isBidding || !isWalletConnected || !sUSDBalance || !gasLimit}
+										onClick={handleBidOrRefund}
+									>
+										{!isBidding
+											? t(`${transKey}.confirm-button.label`)
+											: t(`${transKey}.confirm-button.progress-label`)}
+									</ActionButton>
+								</Tooltip>
+							) : (
+								<ActionButton
+									size="lg"
+									palette="primary"
+									disabled={isAllowing || !isWalletConnected}
+									onClick={handleAllowance}
+								>
+									{!isAllowing
+										? t('common.enable-wallet-access.label')
+										: t('common.enable-wallet-access.progress-label')}
+								</ActionButton>
+							)}
+						</span>
+					</PaddedWithdrawalsTooltip>
 					<PhaseEnd>
 						{t('options.market.trade-card.bidding.footer.end-label')}{' '}
 						<StyledTimeRemaining
@@ -618,6 +608,10 @@ const PaddedWithdrawalsTooltip = withStyles({
 		width: '220px',
 		textAlign: 'center',
 		padding: '10px',
+	},
+	tooltipPlacementTop: {
+		position: 'relative',
+		top: '-10px',
 	},
 })(Tooltip);
 

--- a/src/shared/commonStyles.ts
+++ b/src/shared/commonStyles.ts
@@ -114,7 +114,7 @@ export const LinkTextSmall = styled(DataSmall)`
 export type MessageProps = {
 	size: 'sm' | 'lg';
 	floating?: boolean;
-	type: 'error' | 'success';
+	type: 'error' | 'success' | 'info';
 };
 
 export const Message = styled(FlexDivCentered)<MessageProps>`
@@ -151,6 +151,11 @@ export const Message = styled(FlexDivCentered)<MessageProps>`
 			case 'success': {
 				return css`
 					background-color: ${(props) => props.theme.colors.green};
+				`;
+			}
+			case 'info': {
+				return css`
+					background-color: ${(props) => props.theme.colors.accentL1};
 				`;
 			}
 			default:

--- a/src/shared/translations/en.json
+++ b/src/shared/translations/en.json
@@ -333,8 +333,9 @@
 							"progress-label": "withdrawal in progress..."
 						},
 						"disabled": {
-							"tooltip": "Market Creator has disabled all. withdrawals - sUSD bids are final"
-						}
+							"tooltip": "Market Creator has disabled all. withdrawals - sUSD bids are final",
+							"first-time-tooltip": "WARNING: market creator has disabled withdrawals on this market. All sUSD bids are final."
+						}						
 					},
 					"common": {
 						"current-position": "current position:",

--- a/src/shared/translations/en.json
+++ b/src/shared/translations/en.json
@@ -333,7 +333,7 @@
 							"progress-label": "withdrawal in progress..."
 						},
 						"disabled": {
-							"tooltip": "Market Creator has disabled all. withdrawals - sUSD bids are final",
+							"tooltip": "Market Creator has disabled all withdrawals - sUSD bids are final",
 							"first-time-tooltip": "WARNING: market creator has disabled withdrawals on this market. All sUSD bids are final."
 						}						
 					},


### PR DESCRIPTION
Uses local storage to store the state of tooltip dismissal (per market) as an array.

<img width="424" alt="Screen Shot 2020-07-21 at 2 11 45 pm" src="https://user-images.githubusercontent.com/254095/88012388-287e8a00-cb5d-11ea-9191-302dc943334f.png">
