### PR TITLE
fix: use accessor to enable sorting for 24h change col

### DIFF
--- a/src/pages/Synths/Home/SynthsSection/SynthsTable/SynthsTable.tsx
+++ b/src/pages/Synths/Home/SynthsSection/SynthsTable/SynthsTable.tsx
@@ -102,21 +102,15 @@ export const SynthsTable: FC<SynthsTableProps> = memo(
 							{
 								Header: <>{t('synths.home.table.24h-change-col')}</>,
 								sortType: 'basic',
+								accessor: (originalRow: any) =>
+									get(originalRow.historicalRates, 'ONE_DAY.data.change', null),
 								id: '24change-col',
-								Cell: (cellProps: CellProps<SynthDefinitionWithRates>) => {
-									const change: number | null = get(
-										cellProps.row.original.historicalRates,
-										'ONE_DAY.data.change',
-										null
-									);
-
-									return change == null ? (
+								Cell: (cellProps: CellProps<SynthDefinitionWithRates, number | null>) =>
+									cellProps.cell.value == null ? (
 										<span>{EMPTY_VALUE}</span>
 									) : (
-										<ChangePercent isLabel={true} value={change} />
-									);
-								},
-
+										<ChangePercent isLabel={true} value={cellProps.cell.value} />
+									),
 								sortable: true,
 								width: 100,
 							},


### PR DESCRIPTION
Fixes this:
<img width="394" alt="Screen Shot 2020-07-21 at 9 53 00 pm" src="https://user-images.githubusercontent.com/254095/88051795-939b8100-cb9c-11ea-8d5f-fab57bfca5dc.png">
