### PR TITLE
feat: add vercel headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,95 @@
+{
+	"headers": [
+		{
+			"source": "/static/(.*)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/(.*).ico",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/(.*).(png|jpg|webp|svg)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/(.*).(eot|otf|ttf|ttc|woff|woff2|font|css)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/(.*).(js|css|xml|gz|html|svg)",
+			"headers": [
+				{
+					"key": "Vary",
+					"value": "Accept-Encoding"
+				}
+			]
+		},
+		{
+			"source": "/",
+			"headers": [
+				{
+					"key": "Vary",
+					"value": "Accept-Encoding"
+				}
+			]
+		},
+		{
+			"source": "/(.*)",
+			"headers": [
+				{
+					"key": "X-Content-Type-Options",
+					"value": "nosniff"
+				},
+				{
+					"key": "X-Frame-Options",
+					"value": "DENY"
+				},
+				{
+					"key": "X-XSS-Protection",
+					"value": "1; mode=block"
+				},
+				{
+					"key": "Access-Control-Allow-Credentials",
+					"value": "false"
+				},
+				{
+					"key": "Access-Control-Allow-Origin",
+					"value": "*"
+				},
+				{
+					"key": "Access-Control-Allow-Methods",
+					"value": "GET,POST,OPTIONS"
+				},
+				{
+					"key": "Access-Control-Allow-Headers",
+					"value": "*"
+				},
+				{
+					"key": "Content-Security-Policy",
+					"value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; frame-ancestors 'self'; form-action 'self'; base-uri 'self'; connect-src 'self' *.infura.io www.gasnow.org ethgasstation.info *.portis.io *.bugsnag.com api.thegraph.com wss://api.blocknative.com; frame-src 'self' *.portis.io;"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
changes:
- added `cache-control` headers to improve caching
- added security-related headers: `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`
- added CSP and CORS headers

Signed-off-by: Jakub Mucha <jakub.mucha@icloud.com>